### PR TITLE
Fix typo in man page.

### DIFF
--- a/doc/alex.1.in
+++ b/doc/alex.1.in
@@ -51,7 +51,7 @@ documentation.
 
 .TP
 .BR \-d ", " \-\-debug
-Instructs Alex to generate a lexer which will output debugging messsages
+Instructs Alex to generate a lexer which will output debugging messages
 as it runs.
 
 .TP


### PR DESCRIPTION
I found patch for fixing alex man's typo in Haskell Platform ticket that is created 9 month ago.

  http://trac.haskell.org/haskell-platform/ticket/172

I thought that you missed this Ticket and patch. So, I ported that patch to git repository.
