### PR TITLE
fix warning due to missing !

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -202,7 +202,7 @@ injectCode (Just (AlexPn _ ln _,code)) filename hdl = do
   hPutStrLn hdl code
 
 optsToInject :: Target -> [CLIFlags] -> String
-optsToInject GhcTarget _ = "{-# LANGUAGE CPP,MagicHash #-}\n"
+optsToInject GhcTarget _ = "{-# LANGUAGE CPP,MagicHash,BangPatterns #-}\n"
 optsToInject _         _ = "{-# LANGUAGE CPP #-}\n"
 
 importsToInject :: Target -> [CLIFlags] -> String

--- a/templates/GenericTemplate.hs
+++ b/templates/GenericTemplate.hs
@@ -11,6 +11,7 @@
 #define ILIT(n) n#
 #define FAST_INT_BINDING(n) (n)
 #define IBOX(n) (I# (n))
+#define IBOXBIND(n) !(I# (n))
 #define FAST_INT Int#
 #define LT(n,m) (n <# m)
 #define GTE(n,m) (n >=# m)
@@ -24,6 +25,7 @@
 #define ILIT(n) (n)
 #define FAST_INT_BINDING(n) (n)
 #define IBOX(n) (n)
+#define IBOXBIND(n) (n)
 #define FAST_INT Int
 #define LT(n,m) (n < m)
 #define GTE(n,m) (n >= m)
@@ -158,7 +160,7 @@ alex_scan_tkn user orig_input len input s last_acc =
 #endif
 	let
 		FAST_INT_BINDING(base) = alexIndexInt32OffAddr alex_base s
-		FAST_INT_BINDING(IBOX(ord_c)) = fromIntegral c
+		FAST_INT_BINDING(IBOXBIND(ord_c)) = fromIntegral c
 		FAST_INT_BINDING(offset) = PLUS(base,ord_c)
 		FAST_INT_BINDING(check)  = alexIndexInt16OffAddr alex_check offset
 		


### PR DESCRIPTION
The error message from a missing ! is re-appearing with ghc-7.4.2.  I've attached a patch to fix this.  I think it's compatible through at least ghc-6.12.3 (the earliest version I have available), as well as without ghc extensions.
