### PR TITLE
Fixed Basic Wrapper bug

### DIFF
--- a/templates/wrappers.hs
+++ b/templates/wrappers.hs
@@ -325,8 +325,8 @@ token t input len = return (t input len)
 #ifdef ALEX_BASIC
 type AlexInput = (Char,[Byte],String)
 
-
-alexInputPrevChar (c,_) = c
+alexInputPrevChar :: AlexInput -> Char
+alexInputPrevChar (c,_,_) = c
 
 -- alexScanTokens :: String -> [token]
 alexScanTokens str = go ('\n',[],str)


### PR DESCRIPTION
alexInputPrevChar was short one value in the tuple which cause
an error when using left_ctx.  This patch adds the missing `_`
and includes a type signature which will prevent this bug in
the future.
