### PR TITLE
Fix build of the test suite

### DIFF
--- a/alex.cabal
+++ b/alex.cabal
@@ -108,4 +108,4 @@ executable alex
 test-suite tests
   type: exitcode-stdio-1.0
   main-is: test.hs
-  build-depends: process
+  build-depends: base, process


### PR DESCRIPTION
```
Preprocessing test suite 'tests' for alex-3.0.5...

test.hs:1:1:
    Could not find module `Prelude'
    It is a member of the hidden package `base'.
    Perhaps you need to add `base' to the build-depends in your .cabal file.
    It is a member of the hidden package `haskell98-2.0.0.2'.
    Perhaps you need to add `haskell98' to the build-depends in your .cabal file.
    It is a member of the hidden package `haskell2010-1.1.1.0'.
    Perhaps you need to add `haskell2010' to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.
```
