### PR TITLE
Fixes missing method ignorePendingBytes for ByteString lexers.

### DIFF
--- a/templates/wrappers.hs
+++ b/templates/wrappers.hs
@@ -303,7 +303,7 @@ alexMonadScan = do
         alexMonadScan
     AlexToken inp' len action -> do
         alexSetInput inp'
-        action (ignorePendingBytes inp) len
+        action inp len
 
 -- -----------------------------------------------------------------------------
 -- Useful token actions


### PR DESCRIPTION
The use of ignorePendingBytes in the ByteString
version of alexMonadScan causes an error when
the monad-bytestring or monadUserState-bytestring
wrappers are used.

This is because ignorePendingBytes is not defined,
and since it doesn't appear to be needed for
ByteString based lexers, this change removes the
use of the function from the ByteString version
of alexMonadScan.
