### PR TITLE
macros expanding into preprocessor directives violates C standard?

### DIFF
--- a/templates/GenericTemplate.hs
+++ b/templates/GenericTemplate.hs
@@ -9,27 +9,19 @@
 
 #ifdef ALEX_GHC
 #undef __GLASGOW_HASKELL__
-#define ALEX_IF_GHC_GT_500 #if __GLASGOW_HASKELL__ > 500
-#define ALEX_IF_GHC_LT_503 #if __GLASGOW_HASKELL__ < 503
-#define ALEX_IF_GHC_GT_706 #if __GLASGOW_HASKELL__ > 706
-#define ALEX_ELIF_GHC_500 #elif __GLASGOW_HASKELL__ == 500
-#define ALEX_IF_BIGENDIAN #ifdef WORDS_BIGENDIAN
-#define ALEX_ELSE #else
-#define ALEX_ENDIF #endif
-#define ALEX_DEFINE #define
 #endif
 
 #ifdef ALEX_GHC
 #define ILIT(n) n#
 #define IBOX(n) (I# (n))
 #define FAST_INT Int#
-ALEX_IF_GHC_GT_706
-ALEX_DEFINE GTE(n,m) (tagToEnum# (n >=# m))
-ALEX_DEFINE EQ(n,m) (tagToEnum# (n ==# m))
-ALEX_ELSE
-ALEX_DEFINE GTE(n,m) (n >=# m)
-ALEX_DEFINE EQ(n,m) (n ==# m)
-ALEX_ENDIF
+#if __GLASGOW_HASKELL__ > 706
+#define GTE(n,m) (tagToEnum# (n >=# m))
+#define EQ(n,m) (tagToEnum# (n ==# m))
+#else
+#define GTE(n,m) (n >=# m)
+#define EQ(n,m) (n ==# m)
+#endif
 #define PLUS(n,m) (n +# m)
 #define MINUS(n,m) (n -# m)
 #define TIMES(n,m) (n *# m)
@@ -51,22 +43,22 @@ ALEX_ENDIF
 #ifdef ALEX_GHC
 data AlexAddr = AlexA# Addr#
 
-ALEX_IF_GHC_LT_503
+#if __GLASGOW_HASKELL__ < 503
 uncheckedShiftL# = shiftL#
-ALEX_ENDIF
+#endif
 
 {-# INLINE alexIndexInt16OffAddr #-}
 alexIndexInt16OffAddr (AlexA# arr) off =
-ALEX_IF_BIGENDIAN
+#ifdef WORDS_BIGENDIAN
   narrow16Int# i
   where
         i    = word2Int# ((high `uncheckedShiftL#` 8#) `or#` low)
         high = int2Word# (ord# (indexCharOffAddr# arr (off' +# 1#)))
         low  = int2Word# (ord# (indexCharOffAddr# arr off'))
         off' = off *# 2#
-ALEX_ELSE
+#else
   indexInt16OffAddr# arr off
-ALEX_ENDIF
+#endif
 #else
 alexIndexInt16OffAddr arr off = arr ! off
 #endif
@@ -74,7 +66,7 @@ alexIndexInt16OffAddr arr off = arr ! off
 #ifdef ALEX_GHC
 {-# INLINE alexIndexInt32OffAddr #-}
 alexIndexInt32OffAddr (AlexA# arr) off = 
-ALEX_IF_BIGENDIAN
+#ifdef WORDS_BIGENDIAN
   narrow32Int# i
   where
    i    = word2Int# ((b3 `uncheckedShiftL#` 24#) `or#`
@@ -85,20 +77,20 @@ ALEX_IF_BIGENDIAN
    b1   = int2Word# (ord# (indexCharOffAddr# arr (off' +# 1#)))
    b0   = int2Word# (ord# (indexCharOffAddr# arr off'))
    off' = off *# 4#
-ALEX_ELSE
+#else
   indexInt32OffAddr# arr off
-ALEX_ENDIF
+#endif
 #else
 alexIndexInt32OffAddr arr off = arr ! off
 #endif
 
 #ifdef ALEX_GHC
-ALEX_IF_GHC_LT_503
+#if __GLASGOW_HASKELL__ < 503
 quickIndex arr i = arr ! i
-ALEX_ELSE
+#else
 -- GHC >= 503, unsafeAt is available from Data.Array.Base.
 quickIndex = unsafeAt
-ALEX_ENDIF
+#endif
 #else
 quickIndex arr i = arr ! i
 #endif


### PR DESCRIPTION
The macros ALEX_IF.., ALEX_ENDIF, ALEX_ELIF etc cause failures using alex using GCC 4.2. I'm not sure if this is an actual issue with alex, or an issue using gcc 4.2. 

This patch removes the macros that expand to preprocessor directives.

I suspect this is an issue with alex because of 1973 in 6.10.3.4 of the C0x spec. The same section has a similar restriction for C99.

"The resulting completely macro-replaced preprocessing token sequence is not processed as a preprocessing directive even if it resembles one[...]"

EG: The "resulting" sequence this is referring to is, AFAIK, would be the "#if **GLASGOW_HASKELL** > 500" for the ALEX_IF_GHC_GT_500 macro.

http://c0x.coding-guidelines.com/6.10.3.4.html

An example failure when building yi:

```
Preprocessing library yi-0.7.0...

src/library/Yi/Core.hs:2:14: Warning:
    -XDoRec is deprecated: use -XRecursiveDo or pragma {-# LANGUAGE RecursiveDo #-} instead
line-map.c: file "templates/GenericTemplate.hs" left but not entered

dist/build/Yi/Lexer/Abella.hs:130:0:  error: #else without #if

dist/build/Yi/Lexer/Abella.hs:131:0:  warning: "GTE" redefined

dist/build/Yi/Lexer/Abella.hs:128:0:
     warning: this is the location of the previous definition

dist/build/Yi/Lexer/Abella.hs:132:0:  warning: "EQ" redefined

dist/build/Yi/Lexer/Abella.hs:129:0:
     warning: this is the location of the previous definition

dist/build/Yi/Lexer/Abella.hs:133:0:  error: #endif without #if

dist/build/Yi/Lexer/Abella.hs:184:0:  error: #else without #if

dist/build/Yi/Lexer/Abella.hs:187:0:  error: #endif without #if
```
