### PR TITLE
Whitespace required when using a clang-compiled Alex with gcc

### DIFF
--- a/templates/GenericTemplate.hs
+++ b/templates/GenericTemplate.hs
@@ -23,7 +23,7 @@
 #define ILIT(n) n#
 #define IBOX(n) (I# (n))
 #define FAST_INT Int#
-
+-- Do not remove this comment. Required to fix CPP parsing when using GCC and a clang-compiled alex.
 ALEX_IF_GHC_GT_706
 ALEX_DEFINE GTE(n,m) (tagToEnum# (n >=# m))
 ALEX_DEFINE EQ(n,m) (tagToEnum# (n ==# m))
@@ -51,7 +51,7 @@ ALEX_ENDIF
 
 #ifdef ALEX_GHC
 data AlexAddr = AlexA# Addr#
-
+-- Do not remove this comment. Required to fix CPP parsing when using GCC and a clang-compiled alex.
 ALEX_IF_GHC_LT_503
 uncheckedShiftL# = shiftL#
 ALEX_ENDIF


### PR DESCRIPTION
To the untrained eye (mine), this all seems a bit weird. But here is fix for #36 (and the GHC ticket https://ghc.haskell.org/trac/ghc/ticket/8528).

I think whenever the ALEX_IF_GHC\* macros are used, a blank line needs to precede them.

To reproduce the error and verify the fix: 
1. On Mac OS X mavericks, install the xcode command line utilities, and Haskell Platform 2013.2.0.0. `gcc` will now really be clang. 
2. Install gcc48 from homebrew (or otherwise). It should _not_ replace the gcc on your path.

Use a shim for gcc to enable switching (this is my ~/bin/gcc)

```
#!/bin/sh
/usr/bin/gcc $@
```

Check gcc, for now it should be clang:

```
gcc --version
...
Apple LLVM version 5.0 (clang-500.2.79) (based on LLVM 3.3svn)
...
```

Build and test:

```
$ cd /path/to/alex
$ cabal configure --enable-tests
$ cabal build
$ ./dist/build/tests/tests # Passes
```

Now switch gcc over to a real gcc:

```
#!/bin/sh
/usr/bin/gcc-4.8 $@
```

And run tests again (without recompiling!)

```
$ gcc --version
gcc-4.8 (GCC) 4.8.2
$ ./dist/build/tests/tests
```

Observe all the errors. Like this one:

```
simple.g.hs:360:0:
error: #else without #if
-- INTERNALS and main scanner engine
^
```

With this patch these go away. For now. This is all pretty messy and easy to break in the future. There might be another way that works.
