### PR TITLE
Preventing pre-processor from generating linemarkers.

### DIFF
--- a/Setup.lhs
+++ b/Setup.lhs
@@ -44,7 +44,7 @@ myPostBuild _ flags _ lbi = do
       runProgram p = rawSystemProgramConf verbosity p (withPrograms lbi)
       cpp_template src dst opts = do
         let tmp = dst ++ ".tmp"
-        runProgram ghcProgram (["-o", tmp, "-E", "-cpp", "templates" </> src] ++ opts)
+        runProgram ghcProgram (["-o", tmp, "-E", "-cpp", "-optP-P", "templates" </> src] ++ opts)
         writeFile dst . unlines . map mungeLinePragma . lines =<< readFile tmp
         removeFile tmp
 


### PR DESCRIPTION
This fixes the problem of clang/XCode 5. See
http://www.mail-archive.com/ghc-devs@haskell.org/msg03119.html
