### PR TITLE
Add Functor and Applicative instances for GHC 7.10 compatibility

### DIFF
--- a/src/NFA.hs
+++ b/src/NFA.hs
@@ -23,7 +23,8 @@ import Map ( Map )
 import qualified Map hiding ( Map )
 import Util ( str, space )
 
-import Control.Monad ( forM_, zipWithM, zipWithM_, when )
+import Control.Applicative ( Applicative(..) )
+import Control.Monad ( forM_, zipWithM, zipWithM_, when, liftM, ap )
 import Data.Array ( Array, (!), array, listArray, assocs, bounds )
 
 -- Each state of a nondeterministic automaton contains a list of `Accept'
@@ -161,6 +162,13 @@ rexp2nfa b e (Ques re) = do
 type MapNFA = Map SNum NState
 
 newtype NFAM a = N {unN :: SNum -> MapNFA -> Encoding -> (SNum, MapNFA, a)}
+
+instance Functor NFAM where
+  fmap = liftM
+
+instance Applicative NFAM where
+  pure  = return
+  (<*>) = ap
 
 instance Monad NFAM where
   return a = N $ \s n _ -> (s,n,a)

--- a/src/ParseMonad.hs
+++ b/src/ParseMonad.hs
@@ -19,6 +19,9 @@ import CharSet ( CharSet )
 import Map ( Map )
 import qualified Map hiding ( Map )
 import UTF8
+
+import Control.Applicative ( Applicative(..) )
+import Control.Monad ( liftM, ap )
 import Data.Word (Word8)
 -- -----------------------------------------------------------------------------
 -- The input type
@@ -83,6 +86,13 @@ data PState = PState {
 	     }
 
 newtype P a = P { unP :: PState -> Either ParseError (PState,a) }
+
+instance Functor P where
+  fmap = liftM
+
+instance Applicative P where
+  pure  = return
+  (<*>) = ap
 
 instance Monad P where
  (P m) >>= k = P $ \env -> case m env of


### PR DESCRIPTION
Tested with GHC 7.6.3, 7.8.3, HEAD. Note that alex's dependencies currently need to be installed with `--allow-newer`.

These instances could be perhaps made more efficient (especially fmap), but as they aren't used anywhere (yet), it doesn't really matter (yet).
