### PR TITLE
doc: Add back the abstract to contents page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,6 +2,10 @@
 Alex User Guide
 ===============
 
+Alex is a tool for generating lexical analysers in Haskell, given a description of the tokens to be recognised in
+the form of regular expressions.
+It is similar to the tool "lex" or "flex" for C/C++.
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents


### PR DESCRIPTION
This was lost in the transition, it seems?