### PR TITLE
Doc: Split lines by punctuation

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -1,62 +1,43 @@
-
 .. _about:
 
 About Alex
 ==========
 
-Alex can always be obtained from its `home
-page <http://www.haskell.org/alex>`__. The latest source code lives in
-the `git repository <https://github.com/haskell/alex>`__ on ``GitHub``.
+Alex can always be obtained from its `home page <http://www.haskell.org/alex>`__.
+The latest source code lives in the `git repository <https://github.com/haskell/alex>`__ on ``GitHub``.
 
 .. _bug-reports:
 
 Reporting bugs in Alex
 ----------------------
 
-Please report bugs on the
-`Alex issue tracker <https://github.com/haskell/alex/issues>`__.
-There are no specific mailing lists for the discussion of Alex-related
-matters, but such topics should be fine on the `Haskell Cafe
-<http://www.haskell.org/mailman/listinfo/haskell-cafe>`__ mailing
-list.
+Please report bugs on the `Alex issue tracker <https://github.com/haskell/alex/issues>`__.
+There are no specific mailing lists for the discussion of Alex-related matters,
+but such topics should be fine on the `Haskell Cafe <http://www.haskell.org/mailman/listinfo/haskell-cafe>`__ mailing list.
 
 License
 -------
 
-Copyright (c) 1995-2011, Chris Dornan and Simon Marlow. All rights
-reserved.
+Copyright (c) 1995-2011, Chris Dornan and Simon Marlow.
+All rights reserved.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
--  Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
+-  Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 
--  Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
+-  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
    documentation and/or other materials provided with the distribution.
 
--  Neither the name of the copyright holders, nor the names of the
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
+-  Neither the name of the copyright holders, nor the names of the contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
-OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR APARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 About this documentation
 ------------------------
 
-This documentation is based on a DocBook documentation originally written by
-Chris Dornan, Isaac Jones, and Simon Marlow.
+This documentation is based on a DocBook documentation originally written by Chris Dornan, Isaac Jones, and Simon Marlow.
 
 Converted to RST / Sphinx / readthedocs.org by Andreas Abel in February 2022.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,8 +2,8 @@
 Alex User Guide
 ===============
 
-Alex is a tool for generating lexical analysers in Haskell, given a description of the tokens to be recognised in
-the form of regular expressions.
+Alex is a tool for generating lexical analysers in Haskell,
+given a description of the tokens to be recognised in the form of regular expressions.
 It is similar to the tool "lex" or "flex" for C/C++.
 
 .. toctree::

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -1,14 +1,13 @@
-
 Introduction
 ============
 
-Alex is a tool for generating lexical analysers in Haskell, given a
-description of the tokens to be recognised in the form of regular
-expressions. It is similar to the tools lex and flex for C/C++.
+Alex is a tool for generating lexical analysers in Haskell,
+given a description of the tokens to be recognised in the form of regular expressions.
+It is similar to the tools lex and flex for C/C++.
 
-Alex takes a description of tokens based on regular expressions and
-generates a Haskell module containing code for scanning text
-efficiently. Alex is designed to be familiar to existing lex users,
+Alex takes a description of tokens based on regular expressions and generates a Haskell module containing code for scanning text
+efficiently.
+Alex is designed to be familiar to existing lex users,
 although it does depart from lex in a number of ways.
 
 A sample specification would be the following:
@@ -51,81 +50,68 @@ A sample specification would be the following:
      print (alexScanTokens s)
    }
 
-The first few lines between the ``{`` and ``}`` provide a code scrap
-(some inlined Haskell code) to be placed directly in the output, the
-scrap at the top of the module is normally used to declare the module
-name for the generated Haskell module, in this case ``Main``.
+The first few lines between the ``{`` and ``}`` provide a code scrap (some inlined Haskell code) to be placed directly in the output,
+the scrap at the top of the module is normally used to declare the module name for the generated Haskell module, in this case ``Main``.
 
-The next line, ``%wrapper "basic"`` controls what kind of support code
-Alex should produce along with the basic scanner. The ``basic`` wrapper
-selects a scanner that tokenises a ``String`` and returns a list of
-tokens. Wrappers are described fully in :ref:`The Interface to an
-Alex-generated lexer <api>`.
+The next line, ``%wrapper "basic"`` controls what kind of support code Alex should produce along with the basic scanner.
+The ``basic`` wrapper selects a scanner that tokenises a ``String`` and returns a list of tokens.
+Wrappers are described fully in :ref:`The Interface to an Alex-generated lexer <api>`.
 
-The next two lines define the ``$digit`` and ``$alpha`` macros for use
-in the token definitions.
+The next two lines define the ``$digit`` and ``$alpha`` macros for use in the token definitions.
 
-The ‘\ ``tokens :-``\ ’ line ends the macro definitions and starts the
-definition of the scanner.
+The ‘\ ``tokens :-``\ ’ line ends the macro definitions and starts the definition of the scanner.
 
-The scanner is specified as a series of token definitions where each
-token specification takes the form of
+The scanner is specified as a series of token definitions where each token specification takes the form of
 
 ::
 
    regexp   { code }
 
-The meaning of this rule is "if the input matches <regexp>, then return
-<code>". The code part along with the braces can be replaced by simply
-‘\ ``;``\ ’, meaning that this token should be ignored in the input
-stream. As you can see, we've used this to ignore whitespace in our
-example.
+The meaning of this rule is
+"if the input matches <regexp>, then return <code>".
+The code part along with the braces can be replaced by simply ‘\ ``;``\ ’,
+meaning that this token should be ignored in the input stream.
+As you can see, we've used this to ignore whitespace in our example.
 
-Our scanner is set up so that the actions are all functions with type
-``String->Token``. When the token is matched, the portion of the input
-stream that it matched is passed to the appropriate action function as a
-``String``.
+Our scanner is set up so that the actions are all functions with type ``String->Token``.
+When the token is matched, the portion of the input stream that it matched is passed to the appropriate action function as a ``String``.
 
-At the bottom of the file we have another code fragment, surrounded by
-braces ``{ ... }``. In this fragment, we declare the type of the tokens,
-and give a ``main`` function that we can use for testing it; the
-``main`` function just tokenises the input and prints the results to
-standard output.
+At the bottom of the file we have another code fragment, surrounded by braces ``{ ... }``.
+In this fragment, we declare the type of the tokens, and give a ``main`` function that we can use for testing it;
+the ``main`` function just tokenises the input and prints the results to standard output.
 
-Alex has kindly provided the following function which we can use to
-invoke the scanner:
+Alex has kindly provided the following function which we can use to invoke the scanner:
 
 .. code-block:: haskell
 
    alexScanTokens :: String -> [Token]
 
-Alex arranges for the input stream to be tokenised, each of the action
-functions to be passed the appropriate ``String``, and a list of
-``Token``\ s returned as the result. If the input stream is lazy, the
-output stream will also be produced lazily [1]_.
+Alex arranges for the input stream to be tokenised,
+each of the action functions to be passed the appropriate ``String``,
+and a list of ``Token``\ s returned as the result.
+If the input stream is lazy, the output stream will also be produced lazily [1]_.
 
-We have demonstrated the simplest form of scanner here, which was
-selected by the ``%wrapper "basic"`` line near the top of the file. In
-general, actions do not have to have type ``String->Token``, and there's
-no requirement for the scanner to return a list of tokens.
+We have demonstrated the simplest form of scanner here,
+which was selected by the ``%wrapper "basic"`` line near the top of the file.
+In general, actions do not have to have type ``String->Token``,
+and there's no requirement for the scanner to return a list of tokens.
 
-With this specification in the file ``Tokens.x``, Alex can be used to
-generate ``Tokens.hs``:
+With this specification in the file ``Tokens.x``,
+Alex can be used to generate ``Tokens.hs``:
 
 .. code-block:: sh
 
    $ alex Tokens.x
 
-If the module needed to be placed in a different file, ``Main.hs`` for
-example, then the output filename can be specified using the ``-o``
-option:
+If the module needed to be placed in a different file, ``Main.hs`` for example,
+then the output filename can be specified using the ``-o`` option:
 
 .. code-block:: sh
 
    $ alex Tokens.x -o Main.hs
 
-The resulting module is Haskell 98 compatible. It can also be readily
-used with a `Happy <http://www.haskell.org/happy/>`__ parser.
+The resulting module is Haskell 98 compatible.
+It can also be readily used with a `Happy <http://www.haskell.org/happy/>`__ parser.
 
 .. [1]
    That is, unless you have any patterns that require a long lookahead.

--- a/doc/invoking.rst
+++ b/doc/invoking.rst
@@ -1,4 +1,3 @@
-
 .. _invoking:
 
 Invoking Alex
@@ -10,60 +9,51 @@ The command line syntax for Alex is entirely standard:
 
    $ alex { option } file.x  { option }
 
-Alex expects a single ``file.x`` to be named on the command line. By
-default, Alex will create ``file.hs`` containing the Haskell source for
-the lexer.
+Alex expects a single ``file.x`` to be named on the command line.
+By default, Alex will create ``file.hs`` containing the Haskell source for the lexer.
 
 The options that Alex accepts are listed below:
 
 ``-o`` <file>; ``--outfile``\ =<file>
-   Specifies the filename in which the output is to be placed. By
-   default, this is the name of the input file with the ``.x`` suffix
-   replaced by ``.hs``.
+   Specifies the filename in which the output is to be placed.
+   By default, this is the name of the input file with the ``.x`` suffix replaced by ``.hs``.
 
 ``-i`` [<file>]; ``--info`` [<=file>]
-   Produces a human-readable rendition of the state machine (DFA) that
-   Alex derives from the lexer, in <file> (default: ``file.info`` where
-   the input file is ``file.x``).
+   Produces a human-readable rendition of the state machine (DFA) that Alex derives from the lexer, in <file>
+   (default: ``file.info`` where the input file is ``file.x``).
 
-   The format of the info file is currently a bit basic, and not
-   particularly informative.
+   The format of the info file is currently a bit basic, and not particularly informative.
 
 ``-t`` [<dir>]; ``--template``\ =<dir>
    Look in <dir> for template files.
 
 ``-g``; ``--ghc``
-   Causes Alex to produce a lexer which is optimised for compiling with
-   GHC. The lexer will be significantly more efficient, both in terms of
-   the size of the compiled lexer and its runtime.
+   Causes Alex to produce a lexer which is optimised for compiling with GHC.
+   The lexer will be significantly more efficient,
+   both in terms of the size of the compiled lexer and its runtime.
 
 ``-d``; ``--debug``
-   Causes Alex to produce a lexer which will output debugging messages
-   as it runs.
+   Causes Alex to produce a lexer which will output debugging messages as it runs.
 
 ``-l``; ``--latin1``
-   Disables the use of UTF-8 encoding in the generated lexer. This has
-   two consequences:
+   Disables the use of UTF-8 encoding in the generated lexer.
+   This has two consequences:
 
-   -  The Alex source file is still assumed to be UTF-8 encoded, but any
-      Unicode characters outside the range 0-255 are mapped to Latin-1
-      characters by taking the code point modulo 256.
+   -  The Alex source file is still assumed to be UTF-8 encoded,
+      but any Unicode characters outside the range 0-255 are mapped to Latin-1 characters by taking the code point modulo 256.
 
-   -  The built-in macros ``$printable`` and '``.``' range over the
-      Latin-1 character set, not the Unicode character set.
+   -  The built-in macros ``$printable`` and '``.``' range over the Latin-1 character set, not the Unicode character set.
 
-   Note that this currently does not disable the UTF-8 encoding that
-   happens in the "basic" wrappers, so ``--latin1`` does not make sense
-   in conjunction with these wrappers (not that you would want to do
-   that, anyway). Alternatively, a ``%encoding "latin1"`` declaration
-   can be used inside the Alex source file to request a Latin-1 mapping.
-   See also :ref:`Unicode and UTF-8 <encoding>` for more information about
-   the ``%encoding`` declaration.
+   Note that this currently does not disable the UTF-8 encoding thathappens in the "basic" wrappers,
+   so ``--latin1`` does not make sense in conjunction with these wrappers
+   (not that you would want to do that, anyway).
+   Alternatively, a ``%encoding "latin1"`` declaration can be used inside the Alex source file to request a Latin-1 mapping.
+   See also :ref:`Unicode and UTF-8 <encoding>` for more information about the ``%encoding`` declaration.
 
 ``-?``; ``--help``
    Display help and exit.
 
 ``-V``; ``--version``
-   Output version information and exit. Note that for legacy reasons
-   ``-v`` is supported, too, but the use of it is deprecated. ``-v``
-   will be used for verbose mode when it is actually implemented.
+   Output version information and exit.
+   Note that for legacy reasons ``-v`` is supported, too, but the use of it is deprecated.
+   ``-v`` will be used for verbose mode when it is actually implemented.

--- a/doc/regex.rst
+++ b/doc/regex.rst
@@ -1,11 +1,9 @@
-
 .. _regexps:
 
 Regular Expression
 ==================
 
-Regular expressions are the patterns that Alex uses to match tokens in
-the input stream.
+Regular expressions are the patterns that Alex uses to match tokens in the input stream.
 
 .. _regexp-syntax:
 
@@ -29,24 +27,19 @@ Syntax of regular expressions
             | '{' $digit+ ',' '}'
             | '{' $digit+ ',' $digit+ '}'
 
-The syntax of regular expressions is fairly standard, the only
-difference from normal lex-style regular expressions being that we allow
-the sequence ``()`` to denote the regular expression that matches the
-empty string.
+The syntax of regular expressions is fairly standard,
+the only difference from normal lex-style regular expressions being that we allow the sequence ``()`` to denote the regular expression that matches the empty string.
 
-Spaces are ignored in a regular expression, so feel free to space out
-your regular expression as much as you like, even split it over multiple
-lines and include comments. Literal whitespace can be included by
-surrounding it with quotes ``" "``, or by escaping each whitespace
-character with ``\``.
+Spaces are ignored in a regular expression,
+so feel free to space out your regular expression as much as you like,
+even split it over multiple lines and include comments.
+Literal whitespace can be included by surrounding it with quotes ``" "``, or by escaping each whitespace character with ``\``.
 
 ``set``
-   Matches any of the characters in <set>. See :ref:`Syntax of character
-   sets <charsets>` for the syntax of sets.
+   Matches any of the characters in <set>. See :ref:`Syntax of character sets <charsets>` for the syntax of sets.
 
 ``@foo``
-   Expands to the definition of the appropriate regular expression
-   macro.
+   Expands to the definition of the appropriate regular expression macro.
 
 ``"..."``
    Matches the sequence of characters in the string, in that order.
@@ -74,9 +67,9 @@ character with ``\``.
 Syntax of character sets
 ------------------------
 
-Character sets are the fundamental elements in a regular expression. A
-character set is a pattern that matches a single character. The syntax
-of character sets is as follows:
+Character sets are the fundamental elements in a regular expression.
+A character set is a pattern that matches a single character.
+The syntax of character sets is as follows:
 
 ::
 
@@ -92,28 +85,26 @@ of character sets is as follows:
 The various character set constructions are:
 
 ``char``
-   The simplest character set is a single Unicode character. Note that
-   special characters such as ``[`` and ``.`` must be escaped by
-   prefixing them with ``\`` (see the lexical syntax, :ref:`Lexical
-   syntax <lexical>`, for the list of special characters).
+   The simplest character set is a single Unicode character.
+   Note that special characters such as ``[`` and ``.`` must be escaped by prefixing them with ``\``
+   (see the lexical syntax, :ref:`Lexical syntax <lexical>`, for the list of special characters).
 
-   Certain non-printable characters have special escape sequences. These
-   are: ``\a``, ``\b``, ``\f``, ``\n``, ``\r``, ``\t``, and ``\v``.
-   Other characters can be represented by using their numerical
-   character values (although this may be non-portable): ``\x0A`` is
-   equivalent to ``\n``, for example.
+   Certain non-printable characters have special escape sequences.
+   These are: ``\a``, ``\b``, ``\f``, ``\n``, ``\r``, ``\t``, and ``\v``.
+   Other characters can be represented by using their numerical character values
+   (although this may be non-portable):
+   ``\x0A`` is equivalent to ``\n``, for example.
 
-   Whitespace characters are ignored; to represent a literal space,
-   escape it with ``\``.
+   Whitespace characters are ignored;
+   to represent a literal space, escape it with ``\``.
 
 ``char-char``
-   A range of characters can be expressed by separating the characters
-   with a ‘\ ``-``\ ’, all the characters with codes in the given range
-   are included in the set. Character ranges can also be non-portable.
+   A range of characters can be expressed by separating the characters with a ‘\ ``-``\ ’,
+   all the characters with codes in the given range are included in the set.
+   Character ranges can also be non-portable.
 
 ``.``
-   The built-in set ‘\ ``.``\ ’ matches all characters except newline
-   (``\n``).
+   The built-in set ‘\ ``.``\ ’ matches all characters except newline (``\n``).
 
    Equivalent to the set ``[\x00-\x10ffff] # \n``.
 
@@ -128,10 +119,11 @@ The various character set constructions are:
    ‘\ ``. # [sets]``\ ’.
 
 ``~set``
-   The complement of <set>. Equivalent to ‘\ ``. # set``\ ’
+   The complement of <set>.
+   Equivalent to ‘\ ``. # set``\ ’
 
-A set macro is written as ``$`` followed by an identifier. There are
-some builtin character set macros:
+A set macro is written as ``$`` followed by an identifier.
+There are some builtin character set macros:
 
 ``$white``
    Matches all whitespace characters, including newline.
@@ -139,13 +131,13 @@ some builtin character set macros:
    Equivalent to the set ``[\ \t\n\f\v\r]``.
 
 ``$printable``
-   Matches all "printable characters". Currently this corresponds to
-   Unicode code points 32 to 0x10ffff, although strictly speaking there
-   are many non-printable code points in this region. In the future Alex
-   may use a more precise definition of ``$printable``.
+   Matches all "printable characters".
+   Currently this corresponds to Unicode code points 32 to 0x10ffff,
+   although strictly speaking there are many non-printable code points in this region.
+   In the future Alex may use a more precise definition of ``$printable``.
 
-Character set macros can be defined at the top of the file at the same
-time as regular expression macros (see :ref:`Regular Expression <regexps>`).
+Character set macros can be defined at the top of the file at the same time as regular expression macros
+(see :ref:`Regular Expression <regexps>`).
 Here are some example character set macros:
 
 ::

--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -1,4 +1,3 @@
-
 .. _syntax:
 
 Alex Files
@@ -6,18 +5,17 @@ Alex Files
 
 In this section we describe the layout of an Alex lexical specification.
 
-We begin with the lexical syntax; elements of the lexical syntax are
-referred to throughout the rest of this documentation, so you may need
-to refer back to the following section several times.
+We begin with the lexical syntax; elements of the lexical syntax are referred to throughout the rest of this documentation,
+so you may need to refer back to the following section several times.
 
 .. _lexical:
 
 Lexical syntax
 --------------
 
-Alex's lexical syntax is given below. It is written as a set of macro
-definitions using Alex's own syntax. These macros are used in the BNF
-specification of the syntax later on.
+Alex's lexical syntax is given below.
+It is written as a set of macro definitions using Alex's own syntax.
+These macros are used in the BNF specification of the syntax later on.
 
 ::
 
@@ -40,15 +38,13 @@ specification of the syntax later on.
 Syntax of Alex files
 --------------------
 
-In the following description of the Alex syntax, we use an extended form
-of BNF, where optional phrases are enclosed in square brackets
-(``[ ... ]``), and phrases which may be repeated zero or more times are
-enclosed in braces (``{ ... }``). Literal text is enclosed in single
-quotes.
+In the following description of the Alex syntax, we use an extended form of BNF,
+where optional phrases are enclosed in square brackets (``[ ... ]``),
+and phrases which may be repeated zero or more times are enclosed in braces (``{ ... }``).
+Literal text is enclosed in single quotes.
 
-An Alex lexical specification is normally placed in a file with a ``.x``
-extension. Alex source files are encoded in UTF-8, just like Haskell
-source files [2]_.
+An Alex lexical specification is normally placed in a file with a ``.x`` extension.
+Alex source files are encoded in UTF-8, just like Haskell source files [2]_.
 
 The overall layout of an Alex file is:
 
@@ -56,15 +52,14 @@ The overall layout of an Alex file is:
 
    alex := [ @code ] [ wrapper ] [ encoding ] { macrodef } @id ':-' { rule } [ @code ]
 
-The file begins and ends with optional code fragments. These code
-fragments are copied verbatim into the generated source file.
+The file begins and ends with optional code fragments.
+These code fragments are copied verbatim into the generated source file.
 
-At the top of the file, the code fragment is normally used to declare
-the module name and some imports, and that is all it should do: don't
-declare any functions or types in the top code fragment, because Alex
-may need to inject some imports of its own into the generated lexer
-code, and it does this by adding them directly after this code fragment
-in the output file.
+At the top of the file, the code fragment is normally used to declare the module name and some imports,
+and that is all it should do:
+don't declare any functions or types in the top code fragment,
+because Alex may need to inject some imports of its own into the generated lexer code,
+and it does this by adding them directly after this code fragment in the output file.
 
 Next comes an optional directives section
 
@@ -74,8 +69,8 @@ The first kind of directive is a specification:
 
    wrapper := '%wrapper' @string
 
-wrappers are described in :ref:`Wrappers  <wrappers>`. This can be followed
-by an optional encoding declaration:
+wrappers are described in :ref:`Wrappers  <wrappers>`.
+This can be followed by an optional encoding declaration:
 
 ::
 
@@ -83,8 +78,7 @@ by an optional encoding declaration:
 
 encodings are described in :ref:`Unicode and UTF-8  <encoding>`.
 
-Additionally, you can specify a token type, a typeclass, or an action
-type (depending on what wrapper you use):
+Additionally, you can specify a token type, a typeclass, or an action type (depending on what wrapper you use):
 
 ::
 
@@ -106,11 +100,11 @@ Macro definitions
 ~~~~~~~~~~~~~~~~~
 
 Next, the lexer specification can contain a series of macro definitions.
-There are two kinds of macros, character set macros, which begin with a
-``$``, and regular expression macros, which begin with a ``@``. A
-character set macro can be used wherever a character set is valid (see
-:ref:`Syntax of character sets  <charsets>`), and a regular expression
-macro can be used wherever a regular expression is valid
+There are two kinds of macros, character set macros, which begin with a ``$``,
+and regular expression macros, which begin with a ``@``.
+A character set macro can be used wherever a character set is valid
+(see :ref:`Syntax of character sets  <charsets>`),
+and a regular expression macro can be used wherever a regular expression is valid
 (see :ref:`Regular Expression  <regexps>`).
 
 ::
@@ -121,10 +115,10 @@ macro can be used wherever a regular expression is valid
 Rules
 ~~~~~
 
-The rules are heralded by the sequence ‘\ ``id :-``\ ’ in the file. It
-doesn't matter what you use for the identifier, it is just there for
-documentation purposes. In fact, it can be omitted, but the ``:-`` must
-be left in.
+The rules are heralded by the sequence ‘\ ``id :-``\ ’ in the file.
+It doesn't matter what you use for the identifier,
+it is just there for documentation purposes.
+In fact, it can be omitted, but the ``:-`` must be left in.
 
 The syntax of rules is as follows:
 
@@ -137,40 +131,41 @@ The syntax of rules is as follows:
 
    rhs        := @code | ';'
 
-Each rule defines one token in the lexical specification. When the input
-stream matches the regular expression in a rule, the Alex lexer will
-return the value of the expression on the right hand side, which we call
-the action. The action can be any Haskell expression. Alex only places
-one restriction on actions: all the actions must have the same type.
-They can be values in a token type, for example, or possibly operations
-in a monad. More about how this all works is in
+Each rule defines one token in the lexical specification.
+When the input stream matches the regular expression in a rule,
+the Alex lexer will return the value of the expression on the right hand side,
+which we call the action.
+The action can be any Haskell expression.
+Alex only places one restriction on actions:
+all the actions must have the same type.
+They can be values in a token type, for example, or possibly operations in a monad.
+More about how this all works is in
 :ref:`The Interface to an Alex-generated lexer <api>`.
 
 The action may be missing, indicated by replacing it with ‘\ ``;``\ ’,
 in which case the token will be skipped in the input stream.
 
-Alex will always find the longest match. For example, if we have a rule
-that matches whitespace:
+Alex will always find the longest match.
+For example, if we have a rule that matches whitespace:
 
 ::
 
    $white+        ;
 
-Then this rule will match as much whitespace at the beginning of the
-input stream as it can. Be careful: if we had instead written this rule
-as
+Then this rule will match as much whitespace at the beginning of the input stream as it can.
+Be careful: if we had instead written this rule as
 
 ::
 
    $white*        ;
 
-then it would also match the empty string, which would mean that Alex
-could never fail to match a rule!
+then it would also match the empty string,
+which would mean that Alex could never fail to match a rule!
 
-When the input stream matches more than one rule, the rule which matches
-the longest prefix of the input stream wins. If there are still several
-rules which match an equal number of characters, then the rule which
-appears earliest in the file wins.
+When the input stream matches more than one rule,
+the rule which matches the longest prefix of the input stream wins.
+If there are still several rules which match an equal number of characters,
+then the rule which appears earliest in the file wins.
 
 .. _contexts:
 
@@ -188,27 +183,27 @@ Alex allows a left and right context to be placed on any rule:
                | '/' regexp
                | '/' @code
 
-The left context matches the character which immediately precedes the
-token in the input stream. The character immediately preceding the
-beginning of the stream is assumed to be ‘\ ``\n``\ ’. The special
-left-context ‘\ ``^``\ ’ is shorthand for ‘\ ``\n^``\ ’.
+The left context matches the character which immediately precedes the token in the input stream.
+The character immediately preceding the beginning of the stream is assumed to be ‘\ ``\n``\ ’.
+The special left-context ‘\ ``^``\ ’ is shorthand for ‘\ ``\n^``\ ’.
 
-Right context is rather more general. There are three forms:
+Right context is rather more general.
+There are three forms:
 
 ``/ regexp``
    This right-context causes the rule to match if and only if it is
    followed in the input stream by text which matches <regexp>.
 
-   NOTE: this should be used sparingly, because it can have a serious
-   impact on performance. Any time this rule *could* match, its
-   right-context will be checked against the current input stream.
+   NOTE: this should be used sparingly,
+   because it can have a serious impact on performance.
+   Any time this rule *could* match, its right-context will be checked against the current input stream.
 
 ``$``
    Equivalent to ‘\ ``/\n``\ ’.
 
 ``/ { ... }``
-   This form is called a *predicate* on the rule. The Haskell expression
-   inside the curly braces should have type:
+   This form is called a *predicate* on the rule.
+   The Haskell expression inside the curly braces should have type:
 
    .. code-block:: haskell
 
@@ -218,43 +213,40 @@ Right context is rather more general. There are three forms:
               -> AlexInput  -- input stream after the token
               -> Bool       -- True <=> accept the token
 
-   Alex will only accept the token as matching if the predicate returns
-   ``True``.
+   Alex will only accept the token as matching if the predicate returns ``True``.
 
-   See :ref:`The Interface to an Alex-generated lexer  <api>` for the
-   meaning of the ``AlexInput`` type. The ``user`` argument is available
-   for passing into the lexer a special state which is used by
-   predicates; to give this argument a value, the ``alexScanUser`` entry
-   point to the lexer must be used (see :ref:`Basic interface <basic-api>`).
+   See :ref:`The Interface to an Alex-generated lexer  <api>`
+   for the meaning of the ``AlexInput`` type.
+   The ``user`` argument is available for passing into the lexer a special state which is used by
+   predicates;
+   to give this argument a value, the ``alexScanUser`` entry point to the lexer must be used
+   (see :ref:`Basic interface <basic-api>`).
 
 .. _startcodes:
 
 Start codes
 ^^^^^^^^^^^
 
-Start codes are a way of adding state to a lexical specification, such
-that only certain rules will match for a given state.
+Start codes are a way of adding state to a lexical specification,
+such that only certain rules will match for a given state.
 
-A startcode is simply an identifier, or the special start code
-‘\ ``0``\ ’. Each rule may be given a list of startcodes under which it
-applies:
+A startcode is simply an identifier, or the special start code ‘\ ``0``\ ’.
+Each rule may be given a list of startcodes under which it applies:
 
 ::
 
    startcode  := @id | '0'
    startcodes := '<' startcode { ',' startcode } '>'
 
-When the lexer is invoked to scan the next token from the input stream,
-the start code to use is also specified
+When the lexer is invoked to scan the next token from the input stream, the start code to use is also specified
 (see :ref:`The Interface to an Alex-generated lexer  <api>`).
-Only rules that mention this start code are then enabled. Rules which
-do not have a list of startcodes are available all the time.
+Only rules that mention this start code are then enabled.
+Rules which do not have a list of startcodes are available all the time.
 
-Each distinct start code mentioned in the lexical specification causes a
-definition of the same name to be inserted in the generated source file,
-whose value is of type ``Int``. For example, if we mentioned startcodes
-``foo`` and ``bar`` in the lexical spec, then Alex will create
-definitions such as:
+Each distinct start code mentioned in the lexical specification causes a definition of the same name to be inserted in the generated source file,
+whose value is of type ``Int``.
+For example, if we mentioned startcodes ``foo`` and ``bar`` in the lexical spec,
+then Alex will create definitions such as:
 
 .. code-block:: haskell
 
@@ -263,14 +255,11 @@ definitions such as:
 
 in the output file.
 
-Another way to think of start codes is as a way to define several
-different (but possibly overlapping) lexical specifications in a single
-file, since each start code corresponds to a different set of rules. In
-concrete terms, each start code corresponds to a distinct initial state
-in the state machine that Alex derives from the lexical specification.
+Another way to think of start codes is as a way to define several different (but possibly overlapping) lexical specifications in a single file,
+since each start code corresponds to a different set of rules.
+In concrete terms, each start code corresponds to a distinct initial state in the state machine that Alex derives from the lexical specification.
 
-Here is an example of using startcodes as states, for collecting the
-characters inside a string:
+Here is an example of using startcodes as states, for collecting the characters inside a string:
 
 ::
 
@@ -279,19 +268,19 @@ characters inside a string:
    <string> [^\"]          { stringchar }
    <string> \"             { begin 0 }
 
-When it sees a quotation mark, the lexer switches into the ``string``
-state and each character thereafter causes a ``stringchar`` action,
-until the next quotation mark is found, when we switch back into the
-``0`` state again.
+When it sees a quotation mark,
+the lexer switches into the ``string`` state and each character thereafter causes a ``stringchar`` action,
+until the next quotation mark is found,
+when we switch back into the ``0`` state again.
 
-From the lexer's point of view, the startcode is just an integer passed
-in, which tells it which state to start in. In order to actually use it
-as a state, you must have some way for the token actions to specify new
-start codes - :ref:`The Interface to an Alex-generated lexer <api>`
-describes some ways this can be done. In some applications, it might be
-necessary to keep a *stack* of start codes, where at the end of a state
-we pop the stack and resume parsing in the previous state. If you want
-this functionality, you have to program it yourself.
+From the lexer's point of view,
+the startcode is just an integer passed in,
+which tells it which state to start in. In order to actually use it as a state,
+you must have some way for the token actions to specify new start codes -
+:ref:`The Interface to an Alex-generated lexer <api>` describes some ways this can be done.
+In some applications, it might be necessary to keep a *stack* of start codes,
+where at the end of a state we pop the stack and resume parsing in the previous state.
+If you want this functionality, you have to program it yourself.
 
 .. [2]
    Strictly speaking, GHC source files.


### PR DESCRIPTION
This might look weird at first, but unlike wrapping based on line
length, wrapping based on punction is "stable" across edits.  This is
important, because we it means we can have readable diffs without
drifting away from a (quasi) normal form.