### PR TITLE
Deduplicate docs, prepare to get rid of website

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,1 @@
+doc/contributing.rst

--- a/README.md
+++ b/README.md
@@ -2,88 +2,22 @@
 
 [![Haskell-CI](https://github.com/haskell/alex/actions/workflows/haskell-ci.yml/badge.svg)](https://github.com/haskell/alex/actions/workflows/haskell-ci.yml)
 
-Alex is a Lex-like tool for generating Haskell scanners.  For complete
-documentation, see the doc directory.
+Alex is a tool for generating lexical analysers, also known as "lexers" and "scanners", in Haskell.
+The lexical analysers implement a description of the tokens to be recognised in the form of regular expressions.
+It is similar to the tools "lex" and "flex" for C/C++.
 
-- <https://www.haskell.org/alex/>
+Share and enjoy!
 
-- <https://hackage.haskell.org/package/alex>
+## Documentation
 
-For information on copying and distributing this program, see the file
-LICENSE in this directory.
+Documentation is hosted on [Read the Docs](https://haskell-alex.readthedocs.io):
 
-The sources are in the `src` directory and the documentation in the `doc`
-directory; various  examples are in the `examples` subdirectory.
+- [Online (HTML)](https://haskell-alex.readthedocs.io)
+- [PDF](https://haskell-alex.readthedocs.io/_/downloads/en/latest/pdf/)
+- [Downloadable HTML](https://haskell-alex.readthedocs.io/_/downloads/en/latest/htmlzip/)
 
-The source code in the `src` and `examples` directories is intended to work
-with GHC >= 7.0.
+For basic information of the sort typically found in a read-me, see the following sections of the docs:
 
-## Build Instructions
-
-If you just want to *use* Alex, you can download or install (via
-`cabal install alex`) an
-[Alex release from Hackage](https://hackage.haskell.org/package/alex); also note that
-distributions such as the
-[Haskell Platform](https://www.haskell.org/platform/) and other package
-manager-based distributions provide packages for Alex. Moreover,
-recent versions of `cabal` will automatically install the required
-version of `alex` based on
-[`build-tools`/`build-tool-depends` declarations](http://cabal.readthedocs.io/en/latest/developing-packages.html#pkg-field-build-tool-depends).
-
-Read on if you want to build Alex directly from Git.
-
-Alex is built using GHC & Cabal; so first install
-[GHC](https://www.haskell.org/ghc) and
-[`cabal-install-2.0`](https://www.haskell.org/cabal) (or later).
-
-Since Alex itself is implemented in terms of an Alex scanner,
-bootstrapping Alex is a bit tricky:
-
-You need to have the build-tools `alex` and `happy` manually
-installed; either via your system package manager distribution, the
-Haskell Platform, or e.g. via (run this outside the Git repository!):
-
-    $ cabal install alex happy
-
-which installs them into `${HOME}/.cabal/bin` by default (make sure
-they are in your `$PATH` for the next steps!).
-
-### Variant A
-
-You can install `alex` simply by invoking
-
-    $ cabal install
-
-from inside the Git folder.
-
-### Variant B
-
-Alternatively, you can use the `Makefile` which automates the steps of
-producing a self-contained pre-bootstrapped source distribution with
-pre-generated lexer/scanners:
-
-    $ make sdist
-    $ cabal install dist/alex-*.tar.gz
-
-For convenience, there is also a `make sdist-test` target which builds the
-source source tarball and runs the test-suite from within the source dist.
-
-## Contributing & Reporting Issues
-
-Please report any bugs or comments at  https://github.com/simonmar/alex/issues
-
-Share and enjoy,
-
-Chris Dornan:  cdornan@arm.com
-
-Isaac Jones:   ijones@syntaxpolice.org
-
-Simon Marlow:  simonmar@microsoft.com
-
-and [recent contributors](https://github.com/simonmar/alex/graphs/contributors).
-
-## Current Maintainers
-
-- John Ericson (@Ericson2314)
-
-- Simon Marlow (@simonmar)
+- [About Alex](https://haskell-alex.readthedocs.io/en/latest/about.html)
+- [Obtaining Alex](https://haskell-alex.readthedocs.io/en/latest/obtaining.html)
+- [Contributing](https://haskell-alex.readthedocs.io/en/latest/contributing.html)

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -6,10 +6,16 @@ About Alex
 Alex can always be obtained from its `home page <http://www.haskell.org/alex>`__.
 The latest source code lives in the `git repository <https://github.com/haskell/alex>`__ on ``GitHub``.
 
+Releases
+--------
+
+Releases of Alex are published on `Hackage <https://hackage.haskell.org/package/alex>`__.
+They are also given `Git tags <https://github.com/haskell/alex/tags>`__ in the repository.
+
 .. _bug-reports:
 
-Reporting bugs in Alex
-----------------------
+Reporting issues with Alex
+--------------------------
 
 Please report bugs on the `Alex issue tracker <https://github.com/haskell/alex/issues>`__.
 There are no specific mailing lists for the discussion of Alex-related matters,
@@ -35,9 +41,36 @@ IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
 (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
 HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-About this documentation
-------------------------
+Acknowledgments
+---------------
 
-This documentation is based on a DocBook documentation originally written by Chris Dornan, Isaac Jones, and Simon Marlow.
+Original authors
+~~~~~~~~~~~~~~~~
 
-Converted to RST / Sphinx / readthedocs.org by Andreas Abel in February 2022.
+- Chris Dornan:  cdornan@arm.com
+
+- Isaac Jones:   ijones@syntaxpolice.org
+
+- Simon Marlow:  simonmar@microsoft.com
+
+Current Maintainers
+~~~~~~~~~~~~~~~~~~~
+
+- Andreas Abel (@andreasabel)
+
+- John Ericson (@Ericson2314)
+
+- Simon Marlow (@simonmar)
+
+Other contributor
+~~~~~~~~~~~~~~~~~
+
+The data is in the Git history.
+GitHub can render that in `various ways <https://github.com/simonmar/alex/graphs/contributors>`__.
+
+The documentation itself
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+This documentation is based the original documentation written by Alex's original authors using DocBook.
+
+It was Converted to reStructuredText / Sphinx / readthedocs.org by Andreas Abel in February 2022.

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -1,0 +1,58 @@
+.. _contributing:
+
+Contributing to Alex
+====================
+
+.. highlight:: bash
+
+Source Code Repository
+----------------------
+
+Alex is hosted on `GitHub <https://github.com/haskell/alex>`__.
+As previously discussed in `bug-reports`_, we use the built-in `GitHub issue tracker <https://github.com/haskell/alex/issues>`__ for Alex.
+We also use `GitHub pull requests <https://github.com/haskell/alex/pulls>`__ for managing changes;
+feel free to submit them!
+
+Repo Layout
+-----------
+
+- ``src``: The source code for Alex itself
+- ``doc``: The documentation
+- ``examples``: Various examples of using Alex
+
+Contributor Build Instructions
+------------------------------
+
+Alex is built using `GHC <https://www.haskell.org/ghc>`__ and
+`Cabal Install <https://www.haskell.org/cabal>`__ (version 2.0 or later).
+Make sure they are already installed first.
+
+Since Alex itself is implemented in terms of an Alex scanner,
+bootstrapping Alex is a bit tricky:
+
+You need to have the build-tools ``alex`` and ``happy`` manually installed;
+either via your system package manager distribution, the Haskell Platform, or e.g. via (run this outside the Git repository!)::
+
+   $ cabal install alex happy
+
+which installs them into ``${HOME}/.cabal/bin`` by default.
+(make sure they are in your ``$PATH`` for the next steps!)
+
+Variant A
+~~~~~~~~~
+
+You can install ``alex`` simply by invoking::
+
+   $ cabal install
+
+from inside the Git folder.
+
+Variant B
+~~~~~~~~~
+
+Alternatively, you can use the ``Makefile`` which automates the steps of producing a self-contained pre-bootstrapped source distribution with pre-generated lexer/scanners::
+
+   $ make sdist
+   $ cabal install dist/alex-*.tar.gz
+
+For convenience, there is also a ``make sdist-test`` target which builds the source source tarball and runs the test-suite from within the source dist.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,17 +2,19 @@
 Alex User Guide
 ===============
 
-Alex is a tool for generating lexical analysers in Haskell,
-given a description of the tokens to be recognised in the form of regular expressions.
-It is similar to the tool "lex" or "flex" for C/C++.
+Alex is a tool for generating lexical analysers, also known as "lexers" and "scanners", in Haskell.
+The lexical analysers implement a description of the tokens to be recognised in the form of regular expressions.
+It is similar to the tools "lex" and "flex" for C/C++.
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents
 
    about
+   obtaining
    introduction
    syntax
    regex
    api
    invoking
+   contributing

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -1,9 +1,9 @@
 Introduction
 ============
 
-Alex is a tool for generating lexical analysers in Haskell,
-given a description of the tokens to be recognised in the form of regular expressions.
-It is similar to the tools lex and flex for C/C++.
+Alex is a tool for generating lexical analysers, also known as "lexers" and "scanners", in Haskell.
+The lexical analysers implement a description of the tokens to be recognised in the form of regular expressions.
+It is similar to the tools "lex" and "flex" for C/C++.
 
 Alex takes a description of tokens based on regular expressions and generates a Haskell module containing code for scanning text
 efficiently.

--- a/doc/obtaining.rst
+++ b/doc/obtaining.rst
@@ -1,0 +1,35 @@
+.. _installing:
+
+Obtaining Alex
+==============
+
+.. highlight:: bash
+
+If you just want to *use* Alex, you can build from a release.
+This should work the same as any other Haskell package.
+
+Alex itself and its examples are intended to work with GHC >= 7.0.
+
+Haskell-specific way
+--------------------
+
+From `Hackage <https://hackage.haskell.org/package/alex>`__ via `Cabal Install <https://www.haskell.org/cabal/>`__::
+
+   $ cabal install alex
+
+From `Stackage <https://www.stackage.org/package/alex>`__ via `Stack <https://haskellstack.org>`__::
+
+   $ stack install --resolver nightly alex
+
+Moreover, recent versions of ``cabal`` will automatically install the required version of ``alex`` based on ``build-tools``/``build-tool-depends`` `declarations <http://cabal.readthedocs.io/en/latest/developing-packages.html#pkg-field-build-tool-depends>`__.
+
+Operating System way
+--------------------
+
+Alex might also be pre-packaged for your OS (unconfirmed as of 2022-04-06):
+
+- Ubuntu users: packages should be available from the universe repository.
+- Debian GNU/Linux users: packages are available `here <http://packages.debian.org/alex>`__.
+- FreeBSD/x86 users: Alex is in the ports tree, so either ``pkg_add -r hs-alex``,
+  or install it from the ports tree in ``/usr/ports/devel/hs-alex``.
+- OpenBSD users: Alex is in the -current ports tree, you can install it from ``/usr/ports/devel/alex``.


### PR DESCRIPTION
The idea is that the docs should the source of truth, and be able to replace the website (#215).

Information from the read-me is also moved to the docs.

The `CONTRIBUTING.rst` symlink is intended to do a thing on GitHub (see https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors), but I am not sure how to confirm it will short of merging this PR.