### PR TITLE
Fix out-of-bound access to "alex_check" array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Change in 3.2.7.2
+
+ * Fix bug with out-of-bound access to `alex_check` array.
+
 ## Change in 3.2.7.1
 
  * Fix bug with repeated numeral characters *outside* of `r{n,m}`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Change in 3.2.7.2
 
  * Fix bug with out-of-bound access to `alex_check` array.
+   (Surfaced with GHC's JS backend, fixed by Sylvain Henry in
+    PR [#223](https://github.com/haskell/alex/pull/223).)
+ * Tested with GHC 7.0 - 9.6.1.
+
+_Andreas Abel, 2023-04-03_
 
 ## Change in 3.2.7.1
 

--- a/alex.cabal
+++ b/alex.cabal
@@ -1,6 +1,6 @@
 cabal-version: >= 1.10
 name: alex
-version: 3.2.7.1
+version: 3.2.7.2
 -- don't forget updating changelog.md!
 license: BSD3
 license-file: LICENSE

--- a/data/AlexTemplate.hs
+++ b/data/AlexTemplate.hs
@@ -161,11 +161,15 @@ alex_scan_tkn user__ orig_input len input__ s last_acc =
         let
                 base   = alexIndexInt32OffAddr alex_base s
                 offset = PLUS(base,ord_c)
-                check  = alexIndexInt16OffAddr alex_check offset
 
-                new_s = if GTE(offset,ILIT(0)) && EQ(check,ord_c)
-                          then alexIndexInt16OffAddr alex_table offset
-                          else alexIndexInt16OffAddr alex_deflt s
+                new_s
+                  | GTE(offset,ILIT(0))
+                  , check <- alexIndexInt16OffAddr alex_check offset
+                  , EQ(check,ord_c)
+                  = alexIndexInt16OffAddr alex_table offset
+
+                  | otherwise
+                  = alexIndexInt16OffAddr alex_deflt s
         in
         case new_s of
             ILIT(-1) -> (new_acc, input__)


### PR DESCRIPTION
`offset` can be negative. We must check this before using it to index into `alex_check` array.

Caught with GHC's JS backend (native GHC would only segfault in rare circumstances).