### PR TITLE
v3.2.7.3 amend PR #223 so that it does not need `PatternGuards`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Change in 3.2.7.3
+
+ * Amend last change (3.2.7.2)
+   so that Alex-generated code does not need `LANGUAGE PatternGuards`.
+ * Tested with GHC 7.0 - 9.6.1.
+
+_Andreas Abel, 2023-04-14_
+
 ## Change in 3.2.7.2
 
  * Fix bug with out-of-bound access to `alex_check` array.

--- a/alex.cabal
+++ b/alex.cabal
@@ -1,6 +1,6 @@
 cabal-version: >= 1.10
 name: alex
-version: 3.2.7.2
+version: 3.2.7.3
 -- don't forget updating changelog.md!
 license: BSD3
 license-file: LICENSE

--- a/data/AlexTemplate.hs
+++ b/data/AlexTemplate.hs
@@ -162,14 +162,11 @@ alex_scan_tkn user__ orig_input len input__ s last_acc =
                 base   = alexIndexInt32OffAddr alex_base s
                 offset = PLUS(base,ord_c)
 
-                new_s
-                  | GTE(offset,ILIT(0))
-                  , check <- alexIndexInt16OffAddr alex_check offset
-                  , EQ(check,ord_c)
-                  = alexIndexInt16OffAddr alex_table offset
-
-                  | otherwise
-                  = alexIndexInt16OffAddr alex_deflt s
+                new_s = if GTE(offset,ILIT(0))
+                          && let check  = alexIndexInt16OffAddr alex_check offset
+                             in  EQ(check,ord_c)
+                          then alexIndexInt16OffAddr alex_table offset
+                          else alexIndexInt16OffAddr alex_deflt s
         in
         case new_s of
             ILIT(-1) -> (new_acc, input__)


### PR DESCRIPTION
Amend PR #223 so that created source code does not need `LANGUAGE PatternGuards`.
Plan: release as v3.2.7.3 
Candidate: https://hackage.haskell.org/package/alex-3.2.7.3/candidate