### PR TITLE
Fix #125: put epilogue code last in the generated file.

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20230321
+# version: 0.16
 #
-# REGENDATA ("0.15.20230321",["github","alex.cabal"])
+# REGENDATA ("0.16",["github","alex.cabal"])
 #
 name: Haskell-CI
 on:
@@ -206,8 +206,8 @@ jobs:
       - name: install cabal-plan
         run: |
           mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
-          echo 'de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz' | sha256sum -c -
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.7.3.0/cabal-plan-0.7.3.0-x86_64-linux.xz > cabal-plan.xz
+          echo 'f62ccb2971567a5f638f2005ad3173dba14693a45154c1508645c52289714cb2  cabal-plan.xz' | sha256sum -c -
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+ * The user-supplied "epilogue" Haskell code is now put _last_ in the generated file.
+   This enables use of Template Haskell in the epilogue.
+   (Issue [#125](https://github.com/haskell/alex/issues/125).)
+
 ## Change in 3.2.7.3
 
  * Amend last change (3.2.7.2)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -228,8 +228,6 @@ alex cli file basename script = do
    put_info (infoDFA 1 nm min_dfa "")
    hPutStr out_h (outputDFA target 1 nm scheme min_dfa "")
 
-   injectCode maybe_footer file out_h
-
    hPutStr out_h (sc_hdr "")
    hPutStr out_h (actions "")
 
@@ -241,6 +239,8 @@ alex cli file basename script = do
        | i <- cppDefs ]
      tmplt <- alexReadFile $ template_dir ++ "/AlexTemplate.hs"
      hPutStr out_h tmplt
+
+   injectCode maybe_footer file out_h
 
    hClose out_h
    finish_info

--- a/tests/default_typeclass.x
+++ b/tests/default_typeclass.x
@@ -1,6 +1,7 @@
 {
 {-# LANGUAGE FlexibleContexts, MultiParamTypeClasses, FunctionalDependencies,
              FlexibleInstances #-}
+{-# LANGUAGE TemplateHaskell #-} -- issue #125
 
 module Main (main) where
 import System.Exit
@@ -309,5 +310,26 @@ instance (Functor m, Monad m) => MonadState s (StateT s m) where
 instance (Functor m, Monad m) => Applicative (StateT s m) where
     pure a = state $ \s -> (a, s)
     (<*>) = ap
+
+-- Andreas Abel, 2023-04-14, issue #125
+-- It should be possible to put some Template Haskell here, e.g.
+-- @
+--     makeLenses ''AlexState
+-- @
+-- (with 'makeLenses' from 'lens' or 'microlens-th').
+--
+-- For this to work this "epilogue" code must come last in the generated file.
+-- Otherwise, we get scope errors, e.g.
+--
+--     default_typeclass.x:157:5: error: [GHC-76037]
+--         Not in scope: data constructor ‘AlexError’
+--         |
+--     157 |   case alexScan inp sc of
+--         |     ^^^^^^^^^
+--
+-- It is hard to test 'makeLenses' here because we would need a dependency,
+-- but just any Template Haskell instruction seems to trigger issue #125.
+-- Thus, we confine ourselves to:
+return []
 
 }


### PR DESCRIPTION
Fix #125: put epilogue code last in the generated file.
This enables use of TemplateHaskell there.