### PR TITLE
Fix #228: Remove unused function `Util.brack`.

### DIFF
--- a/src/Util.hs
+++ b/src/Util.hs
@@ -13,7 +13,6 @@ module Util
   , char
   , nl
   , paren
-  , brack
   , interleave_shows
   , space
   , cjustify
@@ -36,9 +35,6 @@ nl = char '\n'
 
 paren :: (String -> String) -> String -> String
 paren s = char '(' . s . char ')'
-
-brack :: (String -> String) -> String -> String
-brack s = char '[' . s . char ']'
 
 interleave_shows :: (String -> String) -> [String -> String] -> String -> String
 interleave_shows _ [] = id


### PR DESCRIPTION
The function `Util.brack` is not used by any part of alex. A quick search through the tree with grep shows this.

Since alex doesn't expose an API and the function is not used internally, it might as well be removed from the module completely.

This pull request removes the function `brack` from the module `Util`.