### PR TITLE
Fix #230: Remove unused functions related to insert sort.

### DIFF
--- a/src/Sort.hs
+++ b/src/Sort.hs
@@ -1,10 +1,8 @@
 {------------------------------------------------------------------------------
                                  SORTING LISTS
 
-This module provides properly parameterised insertion and merge sort functions,
-complete with associated functions for inserting and merging.  `isort' is the
-standard lazy version and can be used to the minimum k elements of a list in
-linear time.  The merge sort is based on a Bob Buckley's (Bob Buckley
+This module provides a properly parameterised merge sort function, complete
+with associated functions. It is based on a Bob Buckley's (Bob Buckley
 18-AUG-95) coding of Knuth's natural merge sort (see Vol. 2).  It seems to be
 fast in the average case; it makes use of natural runs in the data becomming
 linear on ordered data; and it completes in worst time O(n.log(n)).  It is
@@ -21,17 +19,6 @@ module Sort where
 
 -- Hide (<=) so that we don't get name shadowing warnings for it
 import Prelude hiding ((<=))
-
--- `isort' is an insertion sort and is here for historical reasons; msort is
--- better in almost every situation.
-
-isort:: (a->a->Bool) -> [a] -> [a]
-isort (<=) = foldr (insrt (<=)) []
-
-insrt:: (a->a->Bool) -> a -> [a] -> [a]
-insrt _    e [] = [e]
-insrt (<=) e l@(h:t) = if e<=h then e:l else h:insrt (<=) e t
-
 
 msort :: (a->a->Bool) -> [a] -> [a]
 msort _    [] = []                    -- (foldb f []) is undefined


### PR DESCRIPTION
The function `Sort.isort` is not used by any part of alex. A quick search through the tree with `grep` shows this. The function `Sort.insrt` is only ever used by `Sort.isort`.

Since alex doesn't expose an API and the function is not used internally, both can be removed from the module completely.

This commit removes the functions `isort` and `insrt` from the module `Sort`. The comment at the top of the module is adjusted to remove mentions of insert sort or `isort`.