### PR TITLE
v3.2.7.4: Bump and finalize CHANGELOG

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.16
+# version: 0.16.1
 #
-# REGENDATA ("0.16",["github","alex.cabal"])
+# REGENDATA ("0.16.1",["github","alex.cabal"])
 #
 name: Haskell-CI
 on:
@@ -41,9 +41,9 @@ jobs:
             compilerVersion: 9.6.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.4
+          - compiler: ghc-9.4.5
             compilerKind: ghc
-            compilerVersion: 9.4.4
+            compilerVersion: 9.4.5
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
-## Unreleased
+## Change in 3.2.7.4
 
  * The user-supplied "epilogue" Haskell code is now put _last_ in the generated file.
    This enables use of Template Haskell in the epilogue.
    (Issue [#125](https://github.com/haskell/alex/issues/125).)
+ * Tested with GHC 7.0 - 9.6.1.
+
+_Andreas Abel, 2023-05-02_
 
 ## Change in 3.2.7.3
 

--- a/alex.cabal
+++ b/alex.cabal
@@ -1,6 +1,6 @@
 cabal-version: >= 1.10
 name: alex
-version: 3.2.7.3
+version: 3.2.7.4
 -- don't forget updating changelog.md!
 license: BSD3
 license-file: LICENSE
@@ -23,7 +23,7 @@ build-type: Simple
 
 tested-with:
         GHC == 9.6.1
-        GHC == 9.4.4
+        GHC == 9.4.5
         GHC == 9.2.7
         GHC == 9.0.2
         GHC == 8.10.7


### PR DESCRIPTION
Candidate at: https://hackage.haskell.org/package/alex-3.2.7.4/candidate