### PR TITLE
Updated Homepage link which was broken

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -3,7 +3,7 @@
 About Alex
 ==========
 
-Alex can always be obtained from its `home page <http://www.haskell.org/alex>`__.
+Alex can always be obtained from its `home page <https://hackage.haskell.org/package/alex>`__.
 The latest source code lives in the `git repository <https://github.com/haskell/alex>`__ on ``GitHub``.
 
 Releases


### PR DESCRIPTION
Hello. The homepage link was broken and I realised it while reading the webpage on https://haskell-alex.readthedocs.io/en/latest/about.html#  