### PR TITLE
doc(README): remove typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Haskell-CI](https://github.com/haskell/alex/actions/workflows/haskell-ci.yml/badge.svg)](https://github.com/haskell/alex/actions/workflows/haskell-ci.yml)
 
-Alex is a tool for generating lexical analysers, also known as "lexers" and "scanners", in Haskell.
-The lexical analysers implement a description of the tokens to be recognised in the form of regular expressions.
+Alex is a tool for generating lexical analyzers, also known as "lexers" and "scanners", in Haskell.
+The lexical analyzers implement a description of the tokens to be recognised in the form of regular expressions.
 It is similar to the tools "lex" and "flex" for C/C++.
 
 Share and enjoy!


### PR DESCRIPTION
## Description:

This Pull Request fixes a typographical error in the README.md file.


## Changes Made:

 - Corrected "analysers" to "analyzers" in the README.md file.

## Additional Information:

This fix is not related to any existing issue. It's a minor typo that I noticed while reviewing the README.

Thank you for considering this contribution.