### PR TITLE
Closes #220.

### DIFF
--- a/data/AlexWrappers.hs
+++ b/data/AlexWrappers.hs
@@ -360,13 +360,13 @@ alexGetStartCode = Alex $ \s@AlexState{alex_scd=sc} -> Right (s, sc)
 alexSetStartCode :: Int -> Alex ()
 alexSetStartCode sc = Alex $ \s -> Right (s{alex_scd=sc}, ())
 
-#if !defined(ALEX_MONAD_BYTESTRING) && defined(ALEX_MONAD_USER_STATE)
+#if defined(ALEX_MONAD_USER_STATE)
 alexGetUserState :: Alex AlexUserState
 alexGetUserState = Alex $ \s@AlexState{alex_ust=ust} -> Right (s,ust)
 
 alexSetUserState :: AlexUserState -> Alex ()
 alexSetUserState ss = Alex $ \s -> Right (s{alex_ust=ss}, ())
-#endif /* !defined(ALEX_MONAD_BYTESTRING) && defined(ALEX_MONAD_USER_STATE) */
+#endif /* defined(ALEX_MONAD_USER_STATE) */
 
 #ifdef ALEX_MONAD
 alexMonadScan = do


### PR DESCRIPTION
As far as I can tell, disallowing `ALEX_MONAD_USER_STATE` and `ALEX_MONAD_BYTESTRING` together was unintentional.