### PR TITLE
Fix transient CI failures

### DIFF
--- a/.github/workflows/emulated.yml
+++ b/.github/workflows/emulated.yml
@@ -25,7 +25,7 @@ jobs:
         arch: ['s390x', 'ppc64le']
     steps:
     - uses: actions/checkout@v4
-    - uses: uraimo/run-on-arch-action@v2
+    - uses: uraimo/run-on-arch-action@v3
       timeout-minutes: 60
       with:
         arch: ${{ matrix.arch }}


### PR DESCRIPTION
As recommended in https://github.com/haskell/alex/pull/270#issuecomment-2779671749, this PR bumps the version of `run-on-arch-action`, in the hope of getting rid of transient CI errors.