### PR TITLE
add placeholder boot files to simplify local installs

### DIFF
--- a/src/Parser.y.boot
+++ b/src/Parser.y.boot
@@ -1,0 +1,1 @@
+-- placeholder

--- a/src/Scan.x.boot
+++ b/src/Scan.x.boot
@@ -1,0 +1,1 @@
+-- placeholder


### PR DESCRIPTION
This PR is a small quality of life change.

As part of the tarball creation process, the Makefile `sdist` command creates two new files, `src/Scan.x.boot` and `src/Parser.y.boot`. Since we want them included in the resulting tarball, they are also listed in the `extra-source-files` in `alex.cabal`. This creates a bit of friction for developers: as those files do not exist in the repo itself, calls to `cabal install` fail.

To fix this, this PR adds two empty placeholder files. They do not impact any other workflow, but now allow `cabal install` to succeed.