### PR TITLE
release 3.5.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Changes in 3.5.4.1
+
+* New examples and fixes to the documentation (#284, #285, #286).
+* Tested with GHC 8.0 - 9.14.1.
+
+_Andreas Abel, 2026-03-21_
+
 ## Changes in 3.5.4.0
 
 * Fix [issue #277](https://github.com/haskell/alex/issues/277):

--- a/alex.cabal
+++ b/alex.cabal
@@ -9,7 +9,7 @@ author: Chris Dornan and Simon Marlow
 maintainer: https://github.com/haskell/alex
 bug-reports: https://github.com/haskell/alex/issues
 stability: stable
-homepage: http://www.haskell.org/alex/
+homepage: https://github.com/haskell/alex
 synopsis: Alex is a tool for generating lexical analysers in Haskell
 description:
   Alex is a tool for generating lexical analysers in Haskell.

--- a/alex.cabal
+++ b/alex.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.18
 name: alex
-version: 3.5.4.0
+version: 3.5.4.1
 -- don't forget updating changelog.md!
 license: BSD3
 license-file: LICENSE

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -3,8 +3,8 @@
 About Alex
 ==========
 
-Alex can always be obtained from its `home page <https://www.haskell.org/alex>`__.
-The latest source code lives in the `git repository <https://github.com/haskell/alex>`__ on ``GitHub``.
+Alex written in Haskell.
+The source code lives in the `git repository <https://github.com/haskell/alex>`__ on ``GitHub``.
 
 Releases
 --------


### PR DESCRIPTION
- **Remove links to haskell.org/alex**
  
- **Bump to version 3.5.4.1 and CHANGELOG**
  
Candidate: https://hackage.haskell.org/package/alex-3.5.4.1/candidate

Closes #286 
- #286 
